### PR TITLE
Fix Error in Calibrate Chain Lengths Function.

### DIFF
--- a/cnc_ctrl_v1/System.cpp
+++ b/cnc_ctrl_v1/System.cpp
@@ -46,20 +46,16 @@ void  calibrateChainLengths(String gcodeLine){
         Serial.println(F("Measuring out left chain"));
         singleAxisMove(&leftAxis, sysSettings.originalChainLength, (sysSettings.maxFeed * .9));
 
-        Serial.print(leftAxis.read());
+        Serial.print(sysSettings.originalChainLength);
         Serial.println(F("mm"));
-
-        leftAxis.detach();
     }
     else if(extractGcodeValue(gcodeLine, 'R', 0)){
         //measure out the right chain
         Serial.println(F("Measuring out right chain"));
         singleAxisMove(&rightAxis, sysSettings.originalChainLength, (sysSettings.maxFeed * .9));
 
-        Serial.print(rightAxis.read());
+        Serial.print(sysSettings.originalChainLength);
         Serial.println(F("mm"));
-
-        rightAxis.detach();
     }
 
 }


### PR DESCRIPTION
Error is well documented here:  https://forums.maslowcnc.com/t/encoder-steps-issue-with-returning-sprocket-to-12-oclock-after-precise-number-of-links-fed-out-again/6578/17

The problem was that calibrate chains was spooling out more chain
than it was supposed to, while reporting that it had done less
that it was supposed to.

This was caused by calling detach inside the calibrate chain length
function.  This caused the axis to stop moving before the endMove
function had completed.  As a result, the location was listed as
being short of the desired termination point, but since the axis
was agressively stopped, its own momemtum would carry it past
where it was supposed to go.

Solution was to remove detach call.

Also changed print statement about the axis location, if we wanted
to read the axis, we would have to block until the axis settled
first.  There is no need for this, we can report what the commanded
length was.

Thanks for contributing to The Maslow Firmware! You rock.

Please let the community know some basic information about this pull request.

## What does this pull request do?
Does it add a new feature or fix a bug?

## Does this firmware change affect kinematics or any part of the calibration process?
### a) If so, does this change require recalibration?
### b) If so, is there an option for user to opt-out of the change until ready for recalibration? If not, explain why this is not possible.
### c) Has the calibration model in gc/hc/wc been updated to agree with firmware change?
### d) Has this PR been tested on actual machine and/or in fake servo mode (indicate which or both)?

## How can this pull request be tested?
Please provide detailed steps about how to test this pull request.

Thanks for contributing!
